### PR TITLE
Add filters to manage WooCommerce variation stock.

### DIFF
--- a/includes/class-alfaomega-ebooks.php
+++ b/includes/class-alfaomega-ebooks.php
@@ -273,6 +273,8 @@ class Alfaomega_Ebooks {
         $this->loader->add_filter('woocommerce_dropdown_variation_attribute_options_args', $plugin_public, 'product_get_attributes', 10, 2);
         $this->loader->add_filter('woocommerce_dropdown_variation_attribute_options_html', $plugin_public, 'dropdown_variation_attribute_options_html', 10, 2);
         $this->loader->add_filter('woocommerce_variation_is_active', $plugin_public,'deactivate_variation_if_out_of_stock', 10, 2);
+        $this->loader->add_filter('woocommerce_variation_is_purchasable', $plugin_public, 'enable_in_stock_only_variations', 10, 2);
+        $this->loader->add_filter('woocommerce_product_is_in_stock', $plugin_public, 'in_stock_if_any_variation_available', 10, 2);
 
         $this->loader->add_action( 'woocommerce_order_status_completed', $plugin_public, 'on_order_complete' );
         $this->loader->add_shortcode('my_ao_ebooks', $plugin_public, 'my_ao_ebook_shortcode');

--- a/website/class-alfaomega-ebooks-public.php
+++ b/website/class-alfaomega-ebooks-public.php
@@ -333,4 +333,40 @@ class Alfaomega_Ebooks_Public {
         }
         return $active;
     }
+
+    /**
+     * Enable in-stock variations only
+     *
+     * @param bool $purchasable
+     * @param WC_Product_Variation $variation
+     *
+     * @return bool
+     */
+    function enable_in_stock_only_variations($purchasable, $variation) {
+        if (!$variation->is_in_stock()) {
+            return false; // Disable out-of-stock variations
+        }
+        return $purchasable;
+    }
+
+    /**
+     * Enable in-stock variations only
+     *
+     * @param bool $is_in_stock
+     * @param WC_Product $product
+     *
+     * @return bool
+     */
+    function in_stock_if_any_variation_available($is_in_stock, $product) {
+        if ($product->is_type('variable')) {
+            foreach ($product->get_children() as $variation_id) {
+                $variation = wc_get_product($variation_id);
+                if ($variation->is_in_stock()) {
+                    return true; // If any variation is in stock, treat the product as in stock
+                }
+            }
+            return false; // No variations are in stock, mark as out of stock
+        }
+        return $is_in_stock;
+    }
 }


### PR DESCRIPTION
Introduced two new filters in the WooCommerce plugin to enhance stock management for product variations. The first filter disables purchasable status for out-of-stock variations, while the second ensures a product is in stock if any variation is available.