### PR TITLE
update email functionality to handle multiple access codes and improve sample email structure

### DIFF
--- a/src/Services/eBooks/Emails/AlfaomegaEbooksSampleEmail.php
+++ b/src/Services/eBooks/Emails/AlfaomegaEbooksSampleEmail.php
@@ -28,17 +28,21 @@ class AlfaomegaEbooksSampleEmail extends WC_Email {
 
     /**
      * Send the email to the recipient.
-     * @param array $sample
      *
-     * @return void
-     * @throws \Exception
+     * @param array $sample
+     * @param array $accessCodes
+     *
+     * @return bool
      */
-    public function trigger(array $sample): bool {
+    public function trigger(array $sample, array $accessCodes = []): bool {
         if ( ! $sample ) {
             return false;
         }
 
         $this->object = $sample;
+        if (!empty($accessCodes)) {
+            $this->object['code'] = $accessCodes;
+        }
         $recipient = $this->object['destination'] ?? $this->object['promoter'];
         $this->recipient = $recipient;
 

--- a/views/emails/html-sample-email.php
+++ b/views/emails/html-sample-email.php
@@ -20,7 +20,16 @@
     </p>
 
     <p>
-        <?php _e( 'Access code:', 'alfaomega-ebooks') ?> <strong> <?php echo $sample['code'] ?> </strong>
+        <?php _e( 'Access code:', 'alfaomega-ebooks') ?>
+            <?php if(is_string($sample['code'])): ?>
+                <strong> <?php echo $sample['code'] ?> </strong>
+            <?php else: ?>
+                <ul>
+                    <?php foreach($sample['code'] as $code): ?>
+                        <li><strong> <?php echo $code ?> </strong></li>
+                    <?php endforeach; ?>
+                </ul>
+            <?php endif ?>
         <br/>
         <?php if(!empty($sample['due_date'])): ?>
             (<?php _e( 'Valid until:', 'alfaomega-ebooks') ?>


### PR DESCRIPTION
This pull request introduces changes to support multiple access codes in the Alfaomega eBooks system. The updates include modifying email templates, data handling, and post creation logic to accommodate and display multiple codes.

### Email and Access Code Handling:
* Updated `trigger` method in `AlfaomegaEbooksSampleEmail` to accept and process multiple access codes. The `$accessCodes` parameter is now optional and incorporated into the email data if provided.
* Modified `email` method in `SamplePost` to forward multiple access codes to the email trigger function, enabling proper handling of multiple codes.
* Adjusted the email template `html-sample-email.php` to display multiple access codes as a list when applicable.

### Post Creation Logic:
* Enhanced the `updateOrCreate` method in `SamplePost` to generate and track multiple access codes during batch post creation. These codes are aggregated and sent via email after all posts are created. [[1]](diffhunk://#diff-a8e6ee835fc790c678b0e9a4f1804036cb8a31019ff4e69db8304deb2f686ae0R198-L203) [[2]](diffhunk://#diff-a8e6ee835fc790c678b0e9a4f1804036cb8a31019ff4e69db8304deb2f686ae0L212-R229)