### PR TITLE
Enhance the handling of access codes for eBook samples

### DIFF
--- a/src/Services/eBooks/Emails/AlfaomegaEbooksSampleEmail.php
+++ b/src/Services/eBooks/Emails/AlfaomegaEbooksSampleEmail.php
@@ -28,17 +28,21 @@ class AlfaomegaEbooksSampleEmail extends WC_Email {
 
     /**
      * Send the email to the recipient.
-     * @param array $sample
      *
-     * @return void
-     * @throws \Exception
+     * @param array $sample
+     * @param array $accessCodes
+     *
+     * @return bool
      */
-    public function trigger(array $sample): bool {
+    public function trigger(array $sample, array $accessCodes = []): bool {
         if ( ! $sample ) {
             return false;
         }
 
         $this->object = $sample;
+        if (!empty($accessCodes)) {
+            $this->object['code'] = $accessCodes;
+        }
         $recipient = $this->object['destination'] ?? $this->object['promoter'];
         $this->recipient = $recipient;
 

--- a/views/emails/html-sample-email.php
+++ b/views/emails/html-sample-email.php
@@ -20,7 +20,16 @@
     </p>
 
     <p>
-        <?php _e( 'Access code:', 'alfaomega-ebooks') ?> <strong> <?php echo $sample['code'] ?> </strong>
+        <?php _e( 'Access code:', 'alfaomega-ebooks') ?>
+            <?php if(is_string($sample['code'])): ?>
+                <strong> <?php echo $sample['code'] ?> </strong>
+            <?php else: ?>
+                <ul>
+                    <?php foreach($sample['code'] as $code): ?>
+                        <li><strong> <?php echo $code ?> </strong></li>
+                    <?php endforeach; ?>
+                </ul>
+            <?php endif ?>
         <br/>
         <?php if(!empty($sample['due_date'])): ?>
             (<?php _e( 'Valid until:', 'alfaomega-ebooks') ?>


### PR DESCRIPTION
This pull request introduces changes to enhance the handling of access codes for eBook samples, allowing multiple access codes to be sent and displayed. The updates include modifications to email generation, post creation, and email templates to support this functionality.

### Enhancements to Access Code Handling:

* **Email Trigger Method Update**:
  - The `trigger` method in `AlfaomegaEbooksSampleEmail` now accepts an optional `$accessCodes` parameter to handle multiple access codes. If provided, these codes are added to the email object (`src/Services/eBooks/Emails/AlfaomegaEbooksSampleEmail.php`).

* **Email Method Update**:
  - The `email` method in `SamplePost` was updated to pass the `$accessCodes` array to the email trigger, ensuring all generated access codes are included in the email (`src/Services/eBooks/Entities/Alfaomega/SamplePost.php`).

### Improvements to Post Creation:

* **Access Code Generation**:
  - Access codes are now stored in an `$accessCodes` array during post creation, and the description is updated to include the current post number when multiple posts are created (`src/Services/eBooks/Entities/Alfaomega/SamplePost.php`). [[1]](diffhunk://#diff-a8e6ee835fc790c678b0e9a4f1804036cb8a31019ff4e69db8304deb2f686ae0R198-L203) [[2]](diffhunk://#diff-a8e6ee835fc790c678b0e9a4f1804036cb8a31019ff4e69db8304deb2f686ae0L212-R229)

* **Email Sending After Post Creation**:
  - After creating posts, the `email` method is called with the `$accessCodes` array to send all access codes at once (`src/Services/eBooks/Entities/Alfaomega/SamplePost.php`).

### Updates to Email Template:

* **Dynamic Access Code Display**:
  - The email template now dynamically displays either a single access code or a list of codes, depending on whether the `$sample['code']` is a string or an array (`views/emails/html-sample-email.php`).