### PR TITLE
update Product.php and Variant.php to adjust virtual product settings for printed and digital formats

### DIFF
--- a/src/Services/eBooks/Entities/WooCommerce/Product.php
+++ b/src/Services/eBooks/Entities/WooCommerce/Product.php
@@ -271,6 +271,12 @@ class Product extends WooAbstractEntity implements ProductEntity
             if ($newPrice['sales']) {
                 update_post_meta($variation_id, '_sale_price', $newPrice['sales']);
             }
+
+            $variation = wc_get_product($variation_id);
+            if ($variation->get_attribute('pa_book-format') === 'Impreso + Digital' && $variation->get_virtual()) {
+                $variation->set_virtual(false);
+                $variation->save();
+            }
         }
 
         $product->save();

--- a/src/Services/eBooks/Entities/WooCommerce/Variant.php
+++ b/src/Services/eBooks/Entities/WooCommerce/Variant.php
@@ -211,7 +211,7 @@ class Variant extends WooAbstractEntity
                 'sku'             => $product['sku'] . ' (impreso), ' . $ebookIsbn . ' (digital)',
                 'regular_price'   => number_format($prices['regular_price'] * ($this->settings['alfaomega_ebooks_printed_digital_price'] / 100), 0, '', ''),
                 'status'          => 'publish',
-                'virtual'         => true,
+                'virtual'         => false,
                 'downloadable'    => true,
                 'downloads'       => [
                     [ 'name' => 'PDF', 'file' => $ebooksDir . $ebookId ]


### PR DESCRIPTION
This pull request includes updates to the handling of virtual products in the WooCommerce integration. The changes ensure that certain product variations are correctly marked as non-virtual when specific conditions are met.

### Updates to virtual product handling:

* **`updatePrice` method in `Product.php`:** Added logic to check if a product variation with the attribute `pa_book-format` set to "Impreso + Digital" is incorrectly marked as virtual. If so, the variation is updated to be non-virtual and saved.

* **`getData` method in `Variant.php`:** Changed the default value of the `virtual` property for product variants to `false`, ensuring that printed and digital combinations are not marked as virtual by default.