### PR TITLE
update class-alfaomega-ebooks.php to change order completion trigger from 'completed' to 'processing'

### DIFF
--- a/includes/class-alfaomega-ebooks.php
+++ b/includes/class-alfaomega-ebooks.php
@@ -278,7 +278,8 @@ class Alfaomega_Ebooks {
         $this->loader->add_filter('woocommerce_dropdown_variation_attribute_options_html', $plugin_public, 'dropdown_variation_attribute_options_html', 10, 2);
         $this->loader->add_filter('woocommerce_variation_is_active', $plugin_public,'deactivate_variation_if_out_of_stock', 10, 2);
 
-        $this->loader->add_action( 'woocommerce_order_status_completed', $plugin_public, 'on_order_complete' );
+        $this->loader->add_action( 'woocommerce_order_status_processing', $plugin_public, 'on_order_complete' );
+        //$this->loader->add_action( 'woocommerce_order_status_completed', $plugin_public, 'on_order_complete' );
         $this->loader->add_shortcode('my_ao_ebooks', $plugin_public, 'my_ao_ebook_shortcode');
         $this->loader->add_filter('script_loader_tag', $plugin_public, 'alfaomega_add_type_attribute', 10, 3);
 


### PR DESCRIPTION
This pull request includes a small but significant update to the `define_public_hooks` function in the `includes/class-alfaomega-ebooks.php` file. The change modifies the WooCommerce hook for triggering the `on_order_complete` method to respond to the `woocommerce_order_status_processing` status instead of `woocommerce_order_status_completed`. The old hook was commented out for reference.