### PR TITLE
update Order.php to allow access for orders with 'processing' status

### DIFF
--- a/src/Services/eBooks/Entities/WooCommerce/Order.php
+++ b/src/Services/eBooks/Entities/WooCommerce/Order.php
@@ -50,7 +50,7 @@ class Order extends WooAbstractEntity
             $customer_id = get_current_user_id();
         }
 
-        if (empty($customer_id) || $order->get_status() !== 'completed') {
+        if (empty($customer_id) || !in_array($order->get_status(), ['completed', 'processing'])) {
             return [];
         }
 


### PR DESCRIPTION
This pull request modifies the order completion logic in the `onComplete` method of the `Order` entity to include orders with a status of "processing" in addition to "completed."

* [`src/Services/eBooks/Entities/WooCommerce/Order.php`](diffhunk://#diff-a8a761a3ae63bb83330a0386e1a0bfc1f73bd09fbd8f23947e1e5f8534cf6b9fL53-R53): Updated the condition in the `onComplete` method to allow orders with a status of either "completed" or "processing" to proceed.