### PR TITLE
enhance the handling of downloadable file permissions in WooCommerce

### DIFF
--- a/includes/class-alfaomega-ebooks.php
+++ b/includes/class-alfaomega-ebooks.php
@@ -278,7 +278,8 @@ class Alfaomega_Ebooks {
         $this->loader->add_filter('woocommerce_dropdown_variation_attribute_options_html', $plugin_public, 'dropdown_variation_attribute_options_html', 10, 2);
         $this->loader->add_filter('woocommerce_variation_is_active', $plugin_public,'deactivate_variation_if_out_of_stock', 10, 2);
 
-        $this->loader->add_action( 'woocommerce_order_status_processing', $plugin_public, 'on_order_complete' );
+        $this->loader->add_action( 'woocommerce_downloadable_file_permission', $plugin_public, 'on_downloadable_file_permission', 10, 3 );
+        //$this->loader->add_action( 'woocommerce_order_status_processing', $plugin_public, 'on_order_complete' );
         //$this->loader->add_action( 'woocommerce_order_status_completed', $plugin_public, 'on_order_complete' );
         $this->loader->add_shortcode('my_ao_ebooks', $plugin_public, 'my_ao_ebook_shortcode');
         $this->loader->add_filter('script_loader_tag', $plugin_public, 'alfaomega_add_type_attribute', 10, 3);

--- a/includes/class-alfaomega-ebooks.php
+++ b/includes/class-alfaomega-ebooks.php
@@ -278,7 +278,7 @@ class Alfaomega_Ebooks {
         $this->loader->add_filter('woocommerce_dropdown_variation_attribute_options_html', $plugin_public, 'dropdown_variation_attribute_options_html', 10, 2);
         $this->loader->add_filter('woocommerce_variation_is_active', $plugin_public,'deactivate_variation_if_out_of_stock', 10, 2);
 
-        $this->loader->add_action( 'woocommerce_downloadable_file_permission', $plugin_public, 'on_downloadable_file_permission', 10, 3 );
+        $this->loader->add_filter( 'woocommerce_downloadable_file_permission', $plugin_public, 'on_downloadable_file_permission', 10, 5 );
         //$this->loader->add_action( 'woocommerce_order_status_processing', $plugin_public, 'on_order_complete' );
         //$this->loader->add_action( 'woocommerce_order_status_completed', $plugin_public, 'on_order_complete' );
         $this->loader->add_shortcode('my_ao_ebooks', $plugin_public, 'my_ao_ebook_shortcode');

--- a/post_types/class-alfaomega-ebooks-post-type.php
+++ b/post_types/class-alfaomega-ebooks-post-type.php
@@ -181,7 +181,7 @@ if( !class_exists('Alfaomega_Ebooks_Post_Type') ){
         {
             global $pagenow;
 
-            if ($pagenow === 'post.php') {
+            if ($pagenow === 'post.php' && !empty($_GET['post'])) {
                 $ebookPost = Service::make()
                     ->ebooks()
                     ->ebookPost()

--- a/src/Services/eBooks/Entities/WooCommerce/Order.php
+++ b/src/Services/eBooks/Entities/WooCommerce/Order.php
@@ -4,6 +4,7 @@ namespace AlfaomegaEbooks\Services\eBooks\Entities\WooCommerce;
 
 use AlfaomegaEbooks\Services\eBooks\Service;
 use Exception;
+use WC_Customer_Download;
 use WC_Order;
 
 /**

--- a/src/Services/eBooks/Entities/WooCommerce/Order.php
+++ b/src/Services/eBooks/Entities/WooCommerce/Order.php
@@ -3,9 +3,6 @@
 namespace AlfaomegaEbooks\Services\eBooks\Entities\WooCommerce;
 
 use AlfaomegaEbooks\Services\eBooks\Service;
-use Exception;
-use WC_Customer_Download;
-use WC_Order;
 
 /**
  * Class Order

--- a/website/class-alfaomega-ebooks-public.php
+++ b/website/class-alfaomega-ebooks-public.php
@@ -279,23 +279,30 @@ class Alfaomega_Ebooks_Public {
     }
 
     /**
-     * Handles the permission for downloadable files.
+     * Handle the permission for downloadable files.
      *
-     * @param WC_Customer_Download $download The customer download object.
+     * @param WC_Customer_Download $download The download object.
+     * @param WC_Product $product            The product object.
+     * @param WC_Order $order                The order object.
      *
+     * @return void
      * @throws \Exception
      */
-    public function on_downloadable_file_permission($download_id, $product_id, $order): void
-    {
-        if (!empty($order->id)) {
-            $this->on_order_complete($order->id);
+    public function on_downloadable_file_permission(WC_Customer_Download $download,
+                                                    WC_Product $product,
+                                                    WC_Order $order
+    ): WC_Customer_Download {
+        if (! empty($order->get_id())) {
+            $this->on_order_complete($order->get_id());
         } else {
             Service::make()->log('eBook activation failed: ' . json_encode([
-                'download_id' => $download_id,
-                'product_id'  => $product_id,
-                'order'       => $order
-            ], JSON_PRETTY_PRINT));
+                    'download' => $download,
+                    '$product' => $product,
+                    'order'    => $order,
+                ], JSON_PRETTY_PRINT));
         }
+
+        return $download;
     }
 
     /**

--- a/website/class-alfaomega-ebooks-public.php
+++ b/website/class-alfaomega-ebooks-public.php
@@ -279,6 +279,26 @@ class Alfaomega_Ebooks_Public {
     }
 
     /**
+     * Handles the permission for downloadable files.
+     *
+     * @param WC_Customer_Download $download The customer download object.
+     *
+     * @throws \Exception
+     */
+    public function on_downloadable_file_permission($download_id, $product_id, $order): void
+    {
+        if (!empty($order->id)) {
+            $this->on_order_complete($order->id);
+        } else {
+            Service::make()->log('eBook activation failed: ' . json_encode([
+                'download_id' => $download_id,
+                'product_id'  => $product_id,
+                'order'       => $order
+            ], JSON_PRETTY_PRINT));
+        }
+    }
+
+    /**
      * Register the shortcode for displaying the customer's purchased eBooks
      * @return void
      */

--- a/website/class-alfaomega-ebooks-public.php
+++ b/website/class-alfaomega-ebooks-public.php
@@ -281,16 +281,20 @@ class Alfaomega_Ebooks_Public {
     /**
      * Handle the permission for downloadable files.
      *
-     * @param WC_Customer_Download $download The download object.
-     * @param WC_Product $product            The product object.
-     * @param WC_Order $order                The order object.
+     * @param \WC_Customer_Download $download
+     * @param \WC_Product $product
+     * @param \WC_Order $order
+     * @param int $qty
+     * @param \WC_Order_Item $item
      *
-     * @return void
+     * @return \WC_Customer_Download
      * @throws \Exception
      */
     public function on_downloadable_file_permission(WC_Customer_Download $download,
                                                     WC_Product $product,
-                                                    WC_Order $order
+                                                    WC_Order $order,
+                                                    int $qty,
+                                                    WC_Order_Item  $item
     ): WC_Customer_Download {
         if (! empty($order->get_id())) {
             $this->on_order_complete($order->get_id());
@@ -299,6 +303,8 @@ class Alfaomega_Ebooks_Public {
                     'download' => $download,
                     '$product' => $product,
                     'order'    => $order,
+                    'qty'      => $qty,
+                    'item'     => $item
                 ], JSON_PRETTY_PRINT));
         }
 


### PR DESCRIPTION
This pull request introduces changes to enhance the handling of downloadable file permissions in WooCommerce, improve code robustness, and add a new dependency. The most important changes include replacing an action with a filter for file permission handling, adding a new method for managing downloadable file permissions, improving a conditional check in a meta box function, and adding the `WC_Customer_Download` dependency.

### Enhancements to downloadable file handling:
* Replaced the `woocommerce_order_status_processing` action with the `woocommerce_downloadable_file_permission` filter in `define_public_hooks` to handle downloadable file permissions more effectively. The old action was commented out. (`includes/class-alfaomega-ebooks.php`, [includes/class-alfaomega-ebooks.phpL281-R282](diffhunk://#diff-ba927b49732b1107342ff5ef68c3e87a691788e44989844aee49f9569a7c30dcL281-R282))
* Added the `on_downloadable_file_permission` method to manage permissions for downloadable files, including logging in case of failure and invoking the `on_order_complete` method if an order ID is present. (`website/class-alfaomega-ebooks-public.php`, [website/class-alfaomega-ebooks-public.phpR281-R313](diffhunk://#diff-fc26c8d5a18c4d442e370dfe77982d5f6e51a82e3ba528cf59229626607e95faR281-R313))

### Code robustness improvements:
* Updated the conditional check in `add_meta_boxes_view` to ensure the `post` parameter is not empty, preventing potential errors when accessing it. (`post_types/class-alfaomega-ebooks-post-type.php`, [post_types/class-alfaomega-ebooks-post-type.phpL184-R184](diffhunk://#diff-440f43a6c5e78840840218c8ac325a6e45dfe06c523eb235bf3d2e8dc8a7a73fL184-R184))

### Dependency additions:
* Added `WC_Customer_Download` as a dependency in the `Order` entity to support the new functionality for downloadable file permissions. (`src/Services/eBooks/Entities/WooCommerce/Order.php`, [src/Services/eBooks/Entities/WooCommerce/Order.phpR7](diffhunk://#diff-a8a761a3ae63bb83330a0386e1a0bfc1f73bd09fbd8f23947e1e5f8534cf6b9fR7))