### PR TITLE
Enhancements to the handling of downloadable eBook products in a WooCommerce integration

### DIFF
--- a/alfaomega-ebooks.php
+++ b/alfaomega-ebooks.php
@@ -122,4 +122,14 @@ function run_alfaomega_ebooks() {
     }
 }
 
+function order_contains_downloadable_product($order) {
+    foreach ($order->get_items() as $item) {
+        $product = $item->get_product();
+        if ($product && $product->is_downloadable()) {
+            return true;
+        }
+    }
+    return false;
+}
+
 run_alfaomega_ebooks();

--- a/src/Services/eBooks/Entities/WooCommerce/Variant.php
+++ b/src/Services/eBooks/Entities/WooCommerce/Variant.php
@@ -194,7 +194,7 @@ class Variant extends WooAbstractEntity
                 'virtual'         => true,
                 'downloadable'    => true,
                 'downloads'       => [
-                    [ 'name' => 'PDF', 'file' => $ebooksDir . $ebookId ]
+                    [ 'name' => 'eBook', 'file' => $ebooksDir . $ebookId ]
                 ],
                 'download_limit'  => -1,
                 'download_expiry' => 30,
@@ -214,7 +214,7 @@ class Variant extends WooAbstractEntity
                 'virtual'         => false,
                 'downloadable'    => true,
                 'downloads'       => [
-                    [ 'name' => 'PDF', 'file' => $ebooksDir . $ebookId ]
+                    [ 'name' => 'eBook', 'file' => $ebooksDir . $ebookId ]
                 ],
                 'download_limit'  => -1,
                 'download_expiry' => 30,


### PR DESCRIPTION
This pull request introduces enhancements to the handling of downloadable eBook products in a WooCommerce integration. Key changes include the addition of a utility function to check for downloadable products in an order, updates to product variation metadata (e.g., price, stock, and downloadable file names), and standardization of the download name for eBooks.

### Enhancements to WooCommerce product handling:

* **Utility function for downloadable products:**
  - Added `order_contains_downloadable_product` function to check if an order includes a downloadable product.

* **Product variation updates:**
  - Introduced logic to update the `_downloadable_files` metadata for variations, standardizing the download name to "eBook."
  - Updated stock management for variations with the "Impreso + Digital" format, ensuring the `virtual` attribute is set correctly.

* **Download name standardization:**
  - Replaced the download name "PDF" with "eBook" in the `downloads` metadata for product variants. [[1]](diffhunk://#diff-cb70a412849d2a3a0f975987cdfb33ed5ea65915814de69aa340ab41fcbf0337L197-R197) [[2]](diffhunk://#diff-cb70a412849d2a3a0f975987cdfb33ed5ea65915814de69aa340ab41fcbf0337L217-R217)